### PR TITLE
#2: Raw TX body

### DIFF
--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -33,6 +33,7 @@ import           Pos.BlockchainImporter.Tables.Utils
 import           Pos.Core (BlockCount, Timestamp, timestampToUTCTimeL)
 import           Pos.Core.Txp (Tx (..), TxId, TxOut (..), TxOutAux (..), TxUndo)
 import           Pos.Crypto (hash)
+import           Pos.Binary.Class (serialize')
 
 -- txTimestamp corresponds to the trTimestamp
 data TxRecord = TxRecord
@@ -84,7 +85,7 @@ data TxState  = Successful
     Both are needed, as trTimestap is the one the user is interested of knowing, while
     trLastUpdate is used for fetching those events
 -}
-data TxRowPoly h iAddrs iAmts oAddrs oAmts bn t state last = TxRow  { trHash          :: h
+data TxRowPoly h iAddrs iAmts oAddrs oAmts bn t state last raw = TxRow  { trHash          :: h
                                                                     , trInputsAddr    :: iAddrs
                                                                     , trInputsAmount  :: iAmts
                                                                     , trOutputsAddr   :: oAddrs
@@ -93,6 +94,7 @@ data TxRowPoly h iAddrs iAmts oAddrs oAmts bn t state last = TxRow  { trHash    
                                                                     , trTimestamp     :: t
                                                                     , trState         :: state
                                                                     , trLastUpdate    :: last
+                                                                    , trRawBody       :: raw
                                                                     } deriving (Show)
 
 type TxRowPG = TxRowPoly  (Column PGText)                   -- Tx hash
@@ -104,6 +106,7 @@ type TxRowPG = TxRowPoly  (Column PGText)                   -- Tx hash
                           (Column (Nullable PGTimestamptz)) -- Timestamp tx moved to current state
                           (Column PGText)                   -- Tx state
                           (Column PGTimestamptz)            -- Timestamp of the last update
+                          (Column (Nullable PGText))        -- Raw TX body
 
 $(makeAdaptorAndInstance "pTxs" ''TxRowPoly)
 
@@ -117,6 +120,7 @@ txsTable = Table "txs" (pTxs TxRow  { trHash            = required "hash"
                                     , trTimestamp       = required "time"
                                     , trState           = required "tx_state"
                                     , trLastUpdate      = required "last_update"
+                                    , trRawBody         = required "tx_body"
                                     })
 
 

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
@@ -33,6 +33,8 @@ import           Pos.Txp.Toil.Types ()
 hashToString :: AbstractHash algo a -> String
 hashToString h = toString $ sformat hashHexF h
 
+-- We can't store addresses longer than 2K symbols in Pgs because of indexes.
+-- And there are mainnet transactions with addresses up to 10501 symbols long
 cutDownLongAddress :: String -> String
 cutDownLongAddress = take 2000
 

--- a/scripts/generate/blockImporterTables-beta.sql
+++ b/scripts/generate/blockImporterTables-beta.sql
@@ -17,6 +17,7 @@ CREATE TABLE txs 	( hash		          text      PRIMARY KEY
         					, time              timestamp with time zone NULL
                   , tx_state          text      DEFAULT true
                   , last_update       timestamp with time zone
+                  , tx_body           text      DEFAULT NULL
                   );
 
 CREATE TABLE tx_addresses ( tx_hash  text     REFERENCES txs ON DELETE CASCADE


### PR DESCRIPTION
Closes #2 

1. Added new column `tx_body text` to the SQL DB-init script
2. Added the same column to the Opaleye mapping in importer
3. Used `serialize'` to create the raw tx right in the txs table module. **No API has changed.**
4. Had to import `Serokell.Util.Base16` to convert serialised txs to strings

P.S
5. Added comment to the `cutDownLongAddress` that was added in another PR