### PR TITLE
#7 Store block hash

### DIFF
--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -157,9 +157,9 @@ getTxByHash txHash conn = do
     If the tx was already present with a different state, it is moved to the confirmed one and
     it's timestamp and last update are updated
 -}
-upsertSuccessfulTx :: Tx -> TxExtra -> BlockCount -> HeaderHash -> PGS.Connection -> IO ()
-upsertSuccessfulTx tx txExtra blockHeight headerHash =
-   upsertTx tx txExtra (Just (blockHeight, headerHash)) Successful
+upsertSuccessfulTx :: Tx -> TxExtra -> (BlockCount, HeaderHash) -> PGS.Connection -> IO ()
+upsertSuccessfulTx tx txExtra blockHeightAndHash =
+   upsertTx tx txExtra (Just blockHeightAndHash) Successful
 
 {-|
     Inserts a failed tx to the tx history table with the current time as it's timestamp
@@ -261,5 +261,6 @@ currentTxExtra txUndo = do
 instance ToString ByteString where
   toString = toString . SB16.encode
 
+-- | Extracting actual digest from type-wrapper
 extractHash :: HeaderHash -> String
 extractHash (AbstractHash h) = show h

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Global.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Global.hs
@@ -5,14 +5,11 @@ module Pos.BlockchainImporter.Txp.Global
        ) where
 
 import           Universum
-import           System.Wlog (logInfo)
-import           Formatting (sformat, shown, (%))
 
 import           Pos.Core (BlockCount, ComponentBlock (..), HasConfiguration, HasProtocolConstants,
                            HeaderHash, SlotId (..), difficultyL, epochIndexL, getChainDifficulty,
                            headerHash, headerSlotL)
 import           Pos.Core.Txp (TxAux, TxUndo)
-import           Pos.Crypto.Hashing (AbstractHash (..))
 import           Pos.DB (MonadDBRead, SomeBatchOp (..))
 import           Pos.Slotting (getSlotStart)
 import           Pos.Txp (ProcessBlundsSettings (..), TxpBlock, TxpBlund, TxpGlobalApplyMode,
@@ -77,14 +74,12 @@ applySingle isNewEpoch txpBlund = do
 
     let txpBlock = txpBlund ^. _1
     let (slotId, maybeBlockHeight) = getBlockSlotAndHeight txpBlock
-    let (AbstractHash h) = headerHash txpBlock
-    logInfo $ sformat (">>>>> TXP_HASH: "%shown) h
 
     -- Get the timestamp from that information.
     mTxTimestamp <- getSlotStart slotId
 
-    let (txAuxesAndUndos, _) = blundToAuxNUndoWHash txpBlund
-    eApplyToil isNewEpoch mTxTimestamp txAuxesAndUndos maybeBlockHeight
+    let (txAuxesAndUndos, hash) = blundToAuxNUndoWHash txpBlund
+    eApplyToil isNewEpoch mTxTimestamp txAuxesAndUndos maybeBlockHeight hash
 
 rollbackSingle ::
        forall m. (HasConfiguration, HasPostGresDB, MonadIO m, MonadDBRead m)

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
@@ -82,7 +82,7 @@ eApplyToilPG isNewEpoch mTxTimestamp txun headerHash blockHeight = do
             newExtra = TxExtra mTxTimestamp txUndo
 
         postgresStoreOnBlockEvent isNewEpoch $
-                                  TxsT.upsertSuccessfulTx tx newExtra blockHeight headerHash
+                                  TxsT.upsertSuccessfulTx tx newExtra (blockHeight, headerHash)
 
 
 -- | Rollback transactions from one block or genesis.

--- a/scripts/generate/blockImporterTables-beta.sql
+++ b/scripts/generate/blockImporterTables-beta.sql
@@ -14,6 +14,7 @@ CREATE TABLE txs 	( hash		          text      PRIMARY KEY
         					, outputs_address   text[]
                   , outputs_amount    bigint[]
         					, block_num         bigint    NULL
+                  , block_hash        text      NULL
         					, time              timestamp with time zone NULL
                   , tx_state          text      DEFAULT true
                   , last_update       timestamp with time zone


### PR DESCRIPTION
Closing #7 

1. Dragged `HeaderHash` value from the closest location in `Txp/Global.hs` into `TxsTable.hs` into `upsertSuccessfulTx` (the only function where this value makes sense)
2. Bandwagoned `HeaderHash` with the `Maybe BlockCount` to drag it into the actual inserting function `upsertTxToHistory`.
3. Added new column to the Opaleye scheme: `trBlockHash`; actual column name is `"block_hash"`; type - nullable text.
4. Had to implement `extractHash` to extract actual digest from the `AbstractHash` type and to convert it to string. Other than that processing is very similar to the `block_num` value.
5. Added new column definition to the `blockImporterTables-beta.sql` - `block_hash text null`