### PR TITLE
WIP: #11 Slot and Ordinal

### DIFF
--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -167,9 +167,9 @@ getTxByHash txHash conn = do
     If the tx was already present with a different state, it is moved to the confirmed one and
     it's timestamp and last update are updated
 -}
-upsertSuccessfulTx :: Tx -> TxExtra -> SlotId -> (BlockCount, HeaderHash) -> PGS.Connection -> IO ()
-upsertSuccessfulTx tx txExtra slot blockHeightAndHash =
-   upsertTx tx txExtra (Just slot) (Just blockHeightAndHash) Successful
+upsertSuccessfulTx :: Tx -> TxExtra -> SlotId -> (BlockCount, HeaderHash) -> Int -> PGS.Connection -> IO ()
+upsertSuccessfulTx tx txExtra slot blockHeightAndHash ordinal =
+   upsertTx tx txExtra (Just slot) (Just blockHeightAndHash) (Just ordinal) Successful
 
 {-|
     Inserts a failed tx to the tx history table with the current time as it's timestamp
@@ -179,7 +179,7 @@ upsertSuccessfulTx tx txExtra slot blockHeightAndHash =
 upsertFailedTx :: Tx -> TxUndo -> PGS.Connection -> IO ()
 upsertFailedTx tx txUndo conn = do
   txExtra <- currentTxExtra txUndo
-  upsertTx tx txExtra Nothing Nothing Failed conn
+  upsertTx tx txExtra Nothing Nothing Nothing Failed conn
 
 {-|
     Inserts a pending tx to the tx history table with the current time as it's timestamp
@@ -189,7 +189,7 @@ upsertFailedTx tx txUndo conn = do
 upsertPendingTx :: Tx -> TxUndo -> PGS.Connection -> IO ()
 upsertPendingTx tx txUndo conn = do
   txExtra <- currentTxExtra txUndo
-  upsertTx tx txExtra Nothing Nothing Pending conn
+  upsertTx tx txExtra Nothing Nothing Nothing Pending conn
 
 {-|
     Marks all pending txs as failed
@@ -227,15 +227,15 @@ deleteTxsAfterBlk fromBlk conn = void $ runDelete_ conn deleteAfterBlkQuery
 
 -- Inserts a given Tx into the Tx history tables with a given state (overriding any
 -- it if it was already present).
-upsertTx :: Tx -> TxExtra -> Maybe SlotId -> Maybe (BlockCount, HeaderHash) -> TxState -> PGS.Connection -> IO ()
-upsertTx tx txExtra maybeSlot maybeBlockHeightAndHash succeeded conn = do
-  upsertTxToHistory tx txExtra maybeSlot maybeBlockHeightAndHash succeeded conn
+upsertTx :: Tx -> TxExtra -> Maybe SlotId -> Maybe (BlockCount, HeaderHash) -> Maybe Int -> TxState -> PGS.Connection -> IO ()
+upsertTx tx txExtra maybeSlot maybeBlockHeightAndHash maybeOrdinal succeeded conn = do
+  upsertTxToHistory tx txExtra maybeSlot maybeBlockHeightAndHash maybeOrdinal succeeded conn
   TAT.insertTxAddresses tx (teInputOutputs txExtra) conn
 
 -- Inserts the basic info of a given Tx into the master Tx history table (overriding any
 -- it if it was already present)
-upsertTxToHistory :: Tx -> TxExtra-> Maybe SlotId -> Maybe (BlockCount, HeaderHash) -> TxState -> PGS.Connection -> IO ()
-upsertTxToHistory tx TxExtra{..} maybeSlot blockHeightAndHash txState conn = do
+upsertTxToHistory :: Tx -> TxExtra-> Maybe SlotId -> Maybe (BlockCount, HeaderHash) -> Maybe Int -> TxState -> PGS.Connection -> IO ()
+upsertTxToHistory tx TxExtra{..} maybeSlot blockHeightAndHash maybeOrdinal txState conn = do
   currentTime <- getCurrentTime
   void $ runUpsert_ conn txsTable ["hash"]
                     ["block_num", "block_hash", "tx_state", "last_update", "time"]
@@ -258,7 +258,7 @@ upsertTxToHistory tx TxExtra{..} maybeSlot blockHeightAndHash txState conn = do
                 , trRawBody       = toNullable . pgString. toString . serialize' $ tx
                 , trEpoch         = maybeOrNull (pgInt4 . slotToEpochInt) maybeSlot
                 , trSlot          = maybeOrNull (pgInt4 . slotToSlotInt) maybeSlot
-                , trOrdinal       = Opaleye.null
+                , trOrdinal       = maybeOrNull pgInt4 maybeOrdinal
                 }
     timestampToPGTime = pgUTCTime . (^. timestampToUTCTimeL)
 

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -151,7 +151,7 @@ getTxByHash txHash conn = do
   txsMatched  :: [(Text, [Text], [Int64], [Text], [Int64], Maybe Int64, Maybe UTCTime, String)]
               <- runSelect conn txByHashQuery
   pure $ case txsMatched of
-    [ ((_, inpAddrs, inpAmounts, outAddrs, outAmounts, blkNum, t, txStateString)) ] -> do
+    [ (_, inpAddrs, inpAmounts, outAddrs, outAmounts, blkNum, t, txStateString) ] -> do
       inputs <- zipWithM toTxOutAux inpAddrs inpAmounts >>= nonEmpty
       outputs <- zipWithM toTxOutAux outAddrs outAmounts >>= nonEmpty
       txState <- readMaybe txStateString
@@ -160,7 +160,7 @@ getTxByHash txHash conn = do
     _ -> Nothing
     where txByHashQuery = proc () -> do
             TxRow rowTxHash inputsAddr inputsAmount outputsAddr outputsAmount blkNum t txState _ _ _ _ _ _ <- (selectTable txsTable) -< ()
-            restrict -< rowTxHash .== (pgString $ hashToString txHash)
+            restrict -< rowTxHash .== pgString (hashToString txHash)
             A.returnA -< (rowTxHash, inputsAddr, inputsAmount, outputsAddr, outputsAmount, blkNum, t, txState)
 
 -- | Returns slot from a latest known tx or (0/0)
@@ -235,7 +235,7 @@ deleteTxsAfterBlk :: BlockCount -> PGS.Connection -> IO ()
 deleteTxsAfterBlk fromBlk conn = void $ runDelete_ conn deleteAfterBlkQuery
   where deleteAfterBlkQuery = Delete txsTable shouldDeleteTx rCount
         shouldDeleteTx tx   = matchNullable (pgBool False)
-                                            (\txBlkNum -> txBlkNum .> (pgInt8 $ fromIntegral fromBlk))
+                                            (\txBlkNum -> txBlkNum .> pgInt8 (fromIntegral fromBlk))
                                             (trBlockNum tx)
 
 ----------------------------------------------------------------------------

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -253,9 +253,9 @@ upsertTx tx txExtra chainData succeeded conn = do
   upsertTxToHistory tx txExtra chainData succeeded conn
   TAT.insertTxAddresses tx (teInputOutputs txExtra) conn
 
--- Inserts the basic info of a given Tx into the master Tx history table (overriding any
--- it if it was already present)
-upsertTxToHistory :: Tx -> TxExtra-> TxChainData -> TxState -> PGS.Connection -> IO ()
+-- Inserts the basic info of a given Tx into the master Tx history table
+-- (overriding any if it was already present)
+upsertTxToHistory :: Tx -> TxExtra -> TxChainData -> TxState -> PGS.Connection -> IO ()
 upsertTxToHistory tx TxExtra{..} chainData txState conn = do
   currentTime <- getCurrentTime
   void $ runUpsert_ conn txsTable ["hash"]

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -195,9 +195,7 @@ upsertSuccessfulTx tx txExtra slot blockData =
 upsertFailedTx :: Maybe SlotId -> Tx -> TxUndo -> PGS.Connection -> IO ()
 upsertFailedTx maybeSlot tx txUndo conn = do
   txExtra <- currentTxExtra txUndo
-  slot <- case maybeSlot of
-    Just slot -> pure slot
-    Nothing -> getLatestSlot conn
+  slot <- maybe (getLatestSlot conn) pure maybeSlot
   upsertTx tx txExtra (Just slot) Nothing Failed conn
 
 {-|

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -192,10 +192,12 @@ upsertSuccessfulTx tx txExtra slot blockData =
     If the tx was already present with a different state, it is moved to the failed one and
     it's timestamp and last update are updated
 -}
-upsertFailedTx :: Tx -> TxUndo -> PGS.Connection -> IO ()
-upsertFailedTx tx txUndo conn = do
+upsertFailedTx :: Maybe SlotId -> Tx -> TxUndo -> PGS.Connection -> IO ()
+upsertFailedTx maybeSlot tx txUndo conn = do
   txExtra <- currentTxExtra txUndo
-  slot <- getLatestSlot conn
+  slot <- case maybeSlot of
+    Just slot -> pure slot
+    Nothing -> getLatestSlot conn
   upsertTx tx txExtra (Just slot) Nothing Failed conn
 
 {-|

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -173,7 +173,7 @@ getLatestSlot conn = do
   where query = proc () -> do
           (e,s) <- limit 1 (orderBy (desc fst <> desc snd) $ proc () -> do
             TxRow _ _ _ _ _ _ _ txState _ _ _ epoch slot _ <- selectTable txsTable -< ()
-            restrict -< txState .== show Successful
+            restrict -< txState .== pgString (show Successful)
             A.returnA  -< (epoch, slot)) -< ()
           A.returnA -< (fromNullable 0 e, fromNullable 0 s)
 

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/TxsTable.hs
@@ -246,10 +246,8 @@ deleteTxsAfterBlk fromBlk conn = void $ runDelete_ conn deleteAfterBlkQuery
 -- Helpers
 ----------------------------------------------------------------------------
 
-{-|
-    Inserts a given Tx into the Tx history tables with a given state
-    (overriding any it if it was already present).
--}
+-- Inserts a given Tx into the Tx history tables with a given state
+-- (overriding any if it was already present).
 upsertTx :: Tx -> TxExtra -> TxChainData -> TxState -> PGS.Connection -> IO ()
 upsertTx tx txExtra chainData succeeded conn = do
   upsertTxToHistory tx txExtra chainData succeeded conn

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
@@ -6,6 +6,8 @@ module Pos.BlockchainImporter.Tables.Utils
     hashToString
   , addressToString
   , coinToInt64
+  , slotToEpochInt
+  , slotToSlotInt
   , toTxIn
   , toTxOutAux
     -- * Postgres
@@ -20,6 +22,7 @@ import qualified Database.PostgreSQL.Simple as PGS
 import           Formatting (sformat)
 import qualified Opaleye as O
 
+import           Pos.Core (SlotId (..), EpochIndex (..), LocalSlotIndex (..))
 import           Pos.Core.Common (Address, Coin (..), addressF, decodeTextAddress)
 import           Pos.Core.Txp (TxIn (..), TxOut (..), TxOutAux (..))
 import           Pos.Crypto (decodeHash, hashHexF)
@@ -43,6 +46,12 @@ addressToString addr = cutDownLongAddress . toString $ sformat addressF addr
 
 coinToInt64 :: Coin -> Int64
 coinToInt64 = fromIntegral . getCoin
+
+slotToEpochInt :: SlotId -> Int
+slotToEpochInt = fromIntegral . getEpochIndex . siEpoch
+
+slotToSlotInt :: SlotId -> Int
+slotToSlotInt = fromIntegral . getSlotIndex . siSlot
 
 toTxOutAux :: Text -> Int64 -> Maybe TxOutAux
 toTxOutAux receiver amount = do

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
@@ -8,6 +8,7 @@ module Pos.BlockchainImporter.Tables.Utils
   , coinToInt64
   , slotToEpochInt
   , slotToSlotInt
+  , createSlotId
   , toTxIn
   , toTxOutAux
     -- * Postgres
@@ -52,6 +53,11 @@ slotToEpochInt = fromIntegral . getEpochIndex . siEpoch
 
 slotToSlotInt :: SlotId -> Int
 slotToSlotInt = fromIntegral . getSlotIndex . siSlot
+
+createSlotId :: Int -> Int -> SlotId
+createSlotId epoch slot = SlotId { siEpoch = e, siSlot = s }
+  where e = EpochIndex $ fromIntegral epoch
+        s = UnsafeLocalSlotIndex $ fromIntegral slot
 
 toTxOutAux :: Text -> Int64 -> Maybe TxOutAux
 toTxOutAux receiver amount = do

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Global.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Global.hs
@@ -79,7 +79,7 @@ applySingle isNewEpoch txpBlund = do
     mTxTimestamp <- getSlotStart slotId
 
     let (txAuxesAndUndos, hash) = blundToAuxNUndoWHash txpBlund
-    eApplyToil isNewEpoch mTxTimestamp txAuxesAndUndos maybeBlockHeight hash
+    eApplyToil isNewEpoch mTxTimestamp txAuxesAndUndos slotId maybeBlockHeight hash
 
 rollbackSingle ::
        forall m. (HasConfiguration, HasPostGresDB, MonadIO m, MonadDBRead m)

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Local.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Local.hs
@@ -88,7 +88,8 @@ eTxNormalize = withPostGreTransactionM $ do
     extras <- MM.insertionsMap . view eemLocalTxsExtra <$> withTxpLocalData getTxpExtra
     invalidTxs <- txNormalizeAbstract buildEmptyContext (normalizeToil' extras)
     -- Invalid txs previously were in Pending state, so they are updated to the db
-    whenJust invalidTxs $ mapM_ (eFailedToil . taTx)
+    maybeSlot <- getCurrentSlot
+    whenJust invalidTxs $ mapM_ ((eFailedToil maybeSlot) . taTx)
   where
     buildEmptyContext :: Utxo -> [TxAux] -> m ()
     buildEmptyContext _ _ = pure ()

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
@@ -83,9 +83,10 @@ eApplyToilPG isNewEpoch mTxTimestamp txun slot headerHash blockHeight = do
     applier (ordinal, (txAux, txUndo)) = do
         let tx = taTx txAux
             newExtra = TxExtra mTxTimestamp txUndo
-
+        let blockData = TxsT.TxBlockData {
+          blockHeight = blockHeight, blockHash = headerHash, txOrdinal = ordinal}
         postgresStoreOnBlockEvent isNewEpoch $
-                                  TxsT.upsertSuccessfulTx tx newExtra slot (blockHeight, headerHash) ordinal
+                                  TxsT.upsertSuccessfulTx tx newExtra slot blockData
 
 
 -- | Rollback transactions from one block or genesis.

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
@@ -19,7 +19,7 @@ import           Universum
 import           Control.Monad.Except (mapExceptT)
 import qualified Database.PostgreSQL.Simple as PGS
 
-import           Pos.BlockchainImporter.Configuration (HasPostGresDB, postGreOperate)
+import           Pos.BlockchainImporter.Configuration (HasPostGresDB, postGreOperate, withPostGreTransaction)
 import           Pos.BlockchainImporter.Core (TxExtra (..))
 import qualified Pos.BlockchainImporter.Tables.BestBlockTable as BBT
 import qualified Pos.BlockchainImporter.Tables.TxsTable as TxsT
@@ -173,7 +173,7 @@ eNormalizeToil bvd curEpoch txs = catMaybes <$> mapM normalize ordered
 eFailedToil :: (MonadIO m, MonadDBRead m, HasPostGresDB) => Tx -> m ()
 eFailedToil tx = do
   inputs <- fetchTxSenders tx
-  liftIO $ postGreOperate $ TxsT.upsertFailedTx tx inputs
+  liftIO $ withPostGreTransaction . postGreOperate $ TxsT.upsertFailedTx tx inputs
 
 -- | Checks if a tx was successful
 eCheckSuccessfulToil :: (MonadIO m, MonadDBRead m, HasPostGresDB) => Tx -> m Bool

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
@@ -77,15 +77,15 @@ eApplyToilPG isNewEpoch mTxTimestamp txun slot headerHash blockHeight = do
                               UT.applyModifierToUtxos $ applyUTxOModifier txun
 
     -- Update tx history
-    mapM_ applier txun
+    mapM_ applier $ zip [0..] txun
   where
-    applier :: (TxAux, TxUndo) -> m ()
-    applier (txAux, txUndo) = do
+    applier :: (Int, (TxAux, TxUndo)) -> m ()
+    applier (ordinal, (txAux, txUndo)) = do
         let tx = taTx txAux
             newExtra = TxExtra mTxTimestamp txUndo
 
         postgresStoreOnBlockEvent isNewEpoch $
-                                  TxsT.upsertSuccessfulTx tx newExtra slot (blockHeight, headerHash)
+                                  TxsT.upsertSuccessfulTx tx newExtra slot (blockHeight, headerHash) ordinal
 
 
 -- | Rollback transactions from one block or genesis.

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
@@ -170,10 +170,10 @@ eNormalizeToil bvd curEpoch txs = catMaybes <$> mapM normalize ordered
     during it's processing. In that case, we attempt to obtain the inputs, returning them only
     if we successfully get all of them
 -}
-eFailedToil :: (MonadIO m, MonadDBRead m, HasPostGresDB) => Tx -> m ()
-eFailedToil tx = do
+eFailedToil :: (MonadIO m, MonadDBRead m, HasPostGresDB) => Maybe SlotId -> Tx -> m ()
+eFailedToil maybeSlot tx = do
   inputs <- fetchTxSenders tx
-  liftIO $ withPostGreTransaction . postGreOperate $ TxsT.upsertFailedTx tx inputs
+  liftIO $ withPostGreTransaction . postGreOperate $ TxsT.upsertFailedTx maybeSlot tx inputs
 
 -- | Checks if a tx was successful
 eCheckSuccessfulToil :: (MonadIO m, MonadDBRead m, HasPostGresDB) => Tx -> m Bool

--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
@@ -84,9 +84,9 @@ eApplyToilPG isNewEpoch mTxTimestamp txun slot headerHash blockHeight = do
         let tx = taTx txAux
             newExtra = TxExtra mTxTimestamp txUndo
         let blockData = TxsT.TxBlockData {
-          blockHeight = blockHeight, blockHash = headerHash, txOrdinal = ordinal}
+          slot = slot, blockHeight = blockHeight, blockHash = headerHash, txOrdinal = ordinal}
         postgresStoreOnBlockEvent isNewEpoch $
-                                  TxsT.upsertSuccessfulTx tx newExtra slot blockData
+                                  TxsT.upsertSuccessfulTx tx newExtra blockData
 
 
 -- | Rollback transactions from one block or genesis.

--- a/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
@@ -32,6 +32,7 @@ import           Servant.Generic (AsServerT, toServant)
 import           Servant.Server (Server, ServerT, serve)
 
 import           Pos.Crypto (hash)
+import           Pos.Slotting (MonadSlots (getCurrentSlot))
 
 import           Pos.Diffusion.Types (Diffusion (..))
 
@@ -145,7 +146,8 @@ handleSendSTxError txAux sendErr = do
   -- Invalid sent txs should only be inserted to the db if they were not duplicated
   withPostGreTransactionM $ do
     shouldUpsert <- not <$> eCheckSuccessfulToil tx
-    when shouldUpsert $ eFailedToil tx
+    maybeSlot <- getCurrentSlot
+    when shouldUpsert $ eFailedToil maybeSlot tx
   let txHash = hash tx
   throwM $ sendSTxFailureToBIError txHash sendErr
 

--- a/scripts/generate/blockImporterTables-beta.sql
+++ b/scripts/generate/blockImporterTables-beta.sql
@@ -1,3 +1,6 @@
+-- Types
+CREATE DOMAIN posint AS int check (value >= 0);
+
 -- Tables
 CREATE TABLE utxos  ( utxo_id   text      PRIMARY KEY
                     , tx_hash   text
@@ -15,6 +18,9 @@ CREATE TABLE txs 	( hash		          text      PRIMARY KEY
                   , outputs_amount    bigint[]
         					, block_num         bigint    NULL
                   , block_hash        text      NULL
+                  , epoch             posint    NULL
+                  , slot              posint    NULL
+                  , ordinal           posint    NULL
         					, time              timestamp with time zone NULL
                   , tx_state          text      DEFAULT true
                   , last_update       timestamp with time zone

--- a/scripts/generate/blockImporterTables-beta.sql
+++ b/scripts/generate/blockImporterTables-beta.sql
@@ -36,5 +36,7 @@ CREATE TABLE tx_addresses ( tx_hash  text     REFERENCES txs ON DELETE CASCADE
 CREATE INDEX ON utxos (receiver);
 CREATE INDEX ON txs (hash);
 CREATE INDEX ON txs (hash, last_update);
+CREATE INDEX ON txs (epoch, slot);
+CREATE INDEX ON txs (epoch, slot, ordinal);
 CREATE INDEX ON tx_addresses (tx_hash);
 CREATE INDEX ON tx_addresses (address);


### PR DESCRIPTION
## Description

1. When storing successful txs - we also need to store the slot of the block they are included into, and their ordinal number inside that block.

2. When storing failed txs - we also need to assign it the latest known successful slot, so that failed tx can be ordered along the history of successful txs.

## Linked issue

Closing #11 

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
1. Drop existing database
2. Init new database from new SQL script (new columns added)
3. Run importer sync
4. Check importer can successfully store data into DB (no fails)
5. Check in DB that successful txs now contain epoch and slot numbers
6. Check that txs hash correct epoch and slot numbers (may be validated by block hash)
7. Check that successful txs now contain ordinal number
8. Check that txs contain right ordinal number (maybe checked by searching for multiple txs on the same Input/Output inside the same block)
9. Check that failed txs now contain epoch and slot number, but contain NO block hash and ordinal
10. Check that failed tx slot corresponds to closest previous successful tx slot